### PR TITLE
Encapsulation

### DIFF
--- a/lib/NeuralNetwork/Layer/Layer.cpp
+++ b/lib/NeuralNetwork/Layer/Layer.cpp
@@ -1,22 +1,18 @@
 #include "Layer.hpp"
 
-Layer::Layer(std::vector<std::reference_wrapper<double>>  backOutputs, std::vector<std::reference_wrapper<double>> backErrors, int size, const Activation::Activation& activationPair):
+Layer::Layer(std::vector<NeuronInterface>  backInterfaces, int size, const Activation::Activation& activationPair):
 activation(activationPair) {
-    initializeNeurons(backOutputs, backErrors, size);
+    initializeNeurons(backInterfaces, size);
 }
 
-Layer::Layer(std::vector<std::reference_wrapper<double>>  backOutputs, std::vector<std::reference_wrapper<double>> backErrors, int size):
+Layer::Layer(std::vector<NeuronInterface>  backInterfaces, int size):
 activation(Activation::null) {
-    initializeNeurons(backOutputs, backErrors, size);
+    initializeNeurons(backInterfaces, size);
 }
 
-void Layer::initializeNeurons(std::vector<std::reference_wrapper<double>>  outputs, std::vector<std::reference_wrapper<double>> errors, int size) {
-    if(outputs.size() != errors.size()) {
-        throw LayerError();
-    } else {
-        for(int i = 0; i < size; i++) {
-            neurons.emplace_back(new Neuron(outputs, errors));
-        }
+void Layer::initializeNeurons(std::vector<NeuronInterface>  backInterfaces, int size) {
+    for(int i = 0; i < size; i++) {
+        neurons.emplace_back(new Neuron(backInterfaces));
     }
 }
 
@@ -32,18 +28,10 @@ void Layer::backPropogate(const double& learningRate) {
     }
 }
 
-std::vector<std::reference_wrapper<double>>  Layer::getOutputs() {
-    std::vector<std::reference_wrapper<double>> outputs;
+std::vector<NeuronInterface>  Layer::getInterfaces() {
+    std::vector<NeuronInterface> outputs;
     for(auto& neuron : neurons) {
-        outputs.emplace_back(neuron->getOutput());
+        outputs.emplace_back(neuron->getInterface());
     }
     return outputs;
-}
-
-std::vector<std::reference_wrapper<double>> Layer::getErrors() {
-    std::vector<std::reference_wrapper<double>> errors;
-    for(auto& neuron : neurons) {
-        errors.emplace_back(neuron->getError());
-    }
-    return errors;
 }

--- a/lib/NeuralNetwork/Layer/Layer.hpp
+++ b/lib/NeuralNetwork/Layer/Layer.hpp
@@ -8,18 +8,13 @@
 #include <vector>
 #include <memory>
 
-struct LayerError : std::exception {
-  const char* what() const noexcept {return "Neuron must receive the same number of output references as it receives error references\n";}
-};
-
 class Layer {
     public:
-        Layer(std::vector<std::reference_wrapper<double>>  backOutputs, std::vector<std::reference_wrapper<double>> backErrors, int size, const Activation::Activation& activationPair);
-        Layer(std::vector<std::reference_wrapper<double>>  backOutputs, std::vector<std::reference_wrapper<double>> backErrors, int size);
+        Layer(std::vector<NeuronInterface>  backInterfaces, int size, const Activation::Activation& activationPair);
+        Layer(std::vector<NeuronInterface>  backInterfaces, int size);
         virtual void forwardPropogate();
         virtual void backPropogate(const double& learningRate);
-        virtual std::vector<std::reference_wrapper<double>>  getOutputs();
-        virtual std::vector<std::reference_wrapper<double>> getErrors();
+        std::vector<NeuronInterface> getInterfaces();
 
     protected:
         std::vector<std::shared_ptr<Neuron>> neurons;
@@ -27,7 +22,7 @@ class Layer {
 
     private:
         const Activation::Activation& activation;
-        void initializeNeurons(std::vector<std::reference_wrapper<double>> outputs, std::vector<std::reference_wrapper<double>> errors, int size);
+        void initializeNeurons(std::vector<NeuronInterface>  backInterfaces, int size);
 };
 
 #endif

--- a/lib/NeuralNetwork/Layer/SoftmaxLayer.hpp
+++ b/lib/NeuralNetwork/Layer/SoftmaxLayer.hpp
@@ -5,8 +5,8 @@
 
 class SoftmaxLayer : public Layer {
     public:
-        SoftmaxLayer(std::vector<std::reference_wrapper<double>>  backOutputs, std::vector<std::reference_wrapper<double>> backErrors, int size): 
-        Layer(backOutputs, backErrors, size) {};
+        SoftmaxLayer(std::vector<NeuronInterface>  backInterfaces, int size): 
+        Layer(backInterfaces, size) {};
         void forwardPropogate();
         void backPropogate(const double& learningRate);
 };

--- a/lib/NeuralNetwork/Neuron.cpp
+++ b/lib/NeuralNetwork/Neuron.cpp
@@ -1,4 +1,6 @@
 #include "Neuron.hpp"
+#include <cmath>
+#include <cfloat>
 
 Neuron::Neuron(std::vector<NeuronInterface>  backInterfaces): 
 bias(0), 
@@ -22,17 +24,11 @@ void Neuron::forwardPropogate(std::function<const double&(const double&)> activa
 }
 
 void Neuron::softmax(const double& numerator, const double& denominator) {
-    // this smells. fix, but figure out a way to make the rounding to 0 be a problem
-    const double OVERFLOW_MAX = 0.9999999;
-    const double UNDERFLOW_MIN = 0.0000001;
-
-    double raw = numerator / denominator;
-    if(raw > OVERFLOW_MAX) {
-        output = OVERFLOW_MAX;
-    } else if(raw < UNDERFLOW_MIN) {
-        output = UNDERFLOW_MIN;
-    } else {
-        output = raw;
+    output = numerator / denominator;
+    if(output == 0) {
+        output = DBL_MIN;
+    } else if(output == 1) {
+        output = std::nexttoward(double(1), double(0));
     }
 }
 

--- a/lib/NeuralNetwork/Neuron.hpp
+++ b/lib/NeuralNetwork/Neuron.hpp
@@ -6,21 +6,20 @@
 
 class Neuron {
     public:
-        Neuron(std::vector<std::reference_wrapper<double>>  backOutputs, std::vector<std::reference_wrapper<double>> backErrors);
+        Neuron(std::vector<NeuronInterface> backInterfaces);
         double productSum();
         void forwardPropogate(std::function<const double&(const double&)> activation);
         void softmax(const double& numerator, const double& denominator);
         void backPropogate(std::function<const double&(const double&)> activationDerivative, const double& learningRate);
-        double& getOutput();
-        double& getError();
+        const NeuronInterface& getInterface();
         
     private:
         std::vector<Weight> weights;
         double bias;
         double error;
         double output;
-        void initializeWeights(std::vector<std::reference_wrapper<double>>  outputs, std::vector<std::reference_wrapper<double>> errors);
         void adjustWeights(double delta, const double& learningRate);
+        NeuronInterface interface;
 
 };
 

--- a/lib/NeuralNetwork/Weight.cpp
+++ b/lib/NeuralNetwork/Weight.cpp
@@ -1,9 +1,17 @@
 #include "Weight.hpp"
 #include <random>
 
-Weight::Weight(const double& output, double& error): backOutput(output), backError(error) {
+
+InputInterface::InputInterface(std::vector<std::reference_wrapper<double>> input) {
+    for(std::reference_wrapper<double> ref : input) {
+        interfaces.emplace_back([](const double& n){}, ref.get());
+    }
+}
+
+Weight::Weight(NeuronInterface interface): backInterface(interface) {
     std::random_device rd{};
     std::mt19937 gen{rd()};
     std::normal_distribution<double> d{0,1};
     value = d(gen);
 }
+

--- a/lib/NeuralNetwork/Weight.hpp
+++ b/lib/NeuralNetwork/Weight.hpp
@@ -1,11 +1,26 @@
 #ifndef WEIGHT_HPP
 #define WEIGHT_HPP
 
+#include <functional>
+#include <vector>
+
+struct NeuronInterface {
+    NeuronInterface(std::function<void(const double&)> errorAcc, const double& out):
+    errorAccumulator(errorAcc), output(out) {};
+    std::function<void(const double&)> errorAccumulator;
+    const double& output;
+};
+
+
+struct InputInterface {
+    InputInterface(std::vector<std::reference_wrapper<double>> input);
+    std::vector<NeuronInterface> interfaces;
+};
+
 struct Weight {
-    Weight(const double& output, double& error);
+    Weight(NeuronInterface interface);
     double value;
-    const double& backOutput;
-    double& backError;
+    NeuronInterface backInterface;
 };
 
 #endif

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -4,12 +4,12 @@
 #include "MNISTFashion/MNISTLoader.hpp"
 #include "network_parameters.hpp"
 
-int interpretNetworkOutput(const std::vector<double>& networkOutput) {
+int interpretNetworkOutput(const std::vector<NeuronInterface>& interfaces) {
     double highestOutput = 0;
     int highestIndex = 0;
-    for(int i = 0; i < networkOutput.size(); i++) {
-        if(networkOutput[i] > highestOutput) {
-            highestOutput = networkOutput[i];
+    for(int i = 0; i < interfaces.size(); i++) {
+        if(interfaces[i].output > highestOutput) {
+            highestOutput = interfaces[i].output;
             highestIndex = i;
         }
     }
@@ -25,8 +25,7 @@ std::vector<double> labelVector(int label) {
 int main() {
     MNISTLoader loader;
 
-    auto networkOutput = LAYERS.back() -> getOutputs();
-    auto networkError = LAYERS.back() -> getErrors();
+    auto networkInterface = LAYERS.back() -> getInterfaces();
 
     for(auto& data : loader.trainingData()) {
         for(int i = 0; i < INPUT.size(); i++) {
@@ -38,15 +37,15 @@ int main() {
         }
 
         std::cout << "\n\nExpectation: " << data.label;
-        std::cout << "\nPrediction: " << interpretNetworkOutput(std::vector<double>(networkOutput.begin(), networkOutput.end()));
+        std::cout << "\nPrediction: " << interpretNetworkOutput(networkInterface);
         std::cout << "\n\nRaw Outputs:";
         std::vector<double> expectation = labelVector(data.label);
-        for(int i = 0; i < networkOutput.size(); i++) {
-            std::cout << "\n" << networkOutput[i] << " (" << expectation[i] << ")";
+        for(int i = 0; i < networkInterface.size(); i++) {
+            std::cout << "\n" << networkInterface[i].output << " (" << expectation[i] << ")";
         }
 
-        for(int i = 0; i < networkOutput.size(); i++) {
-            networkError[i].get() = LOSS.derivative(networkOutput[i], expectation[i]);
+        for(int i = 0; i < networkInterface.size(); i++) {
+            networkInterface[i].errorAccumulator(LOSS.derivative(networkInterface[i].output, expectation[i]));
         }
 
         for(int i = LAYERS.size() - 1; i >= 0; i--) {

--- a/lib/network_parameters.hpp
+++ b/lib/network_parameters.hpp
@@ -9,8 +9,12 @@ const double LEARNING_RATE = 0.001;
 std::array<double, 784> INPUT;
 std::array<double, 784> TOTAL_ERROR;
 
-Layer hiddenLayer({INPUT.begin(), INPUT.end()}, {TOTAL_ERROR.begin(), TOTAL_ERROR.end()}, 500, Activation::relu);
-SoftmaxLayer outputLayer(hiddenLayer.getOutputs(), hiddenLayer.getErrors(), 10);
+
+//yea, when I pull this out to the input layer it feels weird
+InputInterface INPUT_INTERFACE({INPUT.begin(), INPUT.end()});
+
+Layer hiddenLayer(INPUT_INTERFACE.interfaces, 500, Activation::relu);
+SoftmaxLayer outputLayer(hiddenLayer.getInterfaces(), 10);
 
 auto LOSS = Loss::binaryCrossEntropy;
 


### PR DESCRIPTION
Encapsulates the neuron class a little better by distributing functions to accumulate the error for a neuron during back propogation instead of passing a raw reference, and making sure to use const references for the output.